### PR TITLE
AssetDatabase replacement

### DIFF
--- a/Assets/Resources/audio_asset_table.json
+++ b/Assets/Resources/audio_asset_table.json
@@ -1,0 +1,44 @@
+{
+    "AssetPaths": [
+        {
+            "name": "idea_theme",
+            "path": "Audio\\idea_theme"
+        },
+        {
+            "name": "reflections_game",
+            "path": "Audio\\reflections_game"
+        },
+        {
+            "name": "paper_unravel",
+            "path": "Audio\\paper_unravel"
+        },
+        {
+            "name": "object_obtained",
+            "path": "Audio\\object_obtained"
+        },
+        {
+            "name": "non_interactable",
+            "path": "Audio\\non_interactable"
+        },
+        {
+            "name": "Handkerchief",
+            "path": "Audio\\Section1\\Handkerchief"
+        },
+        {
+            "name": "placeholder",
+            "path": "Audio\\Voicelines\\placeholder"
+        },
+        {
+            "name": "main_door",
+            "path": "Audio\\Section1\\main_door"
+        },
+        {
+            "name": "footstep_wood",
+            "path": "Audio\\footstep_wood"
+        },
+        {
+            "name": "Fusebox",
+            "path": "Audio\\Section1\\Fusebox"
+        }
+    ]
+}

--- a/Assets/Resources/audio_asset_table.json.meta
+++ b/Assets/Resources/audio_asset_table.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0e79847cfaea0754db6d0537e109049c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/EventManager.cs
+++ b/Assets/Scripts/EventManager.cs
@@ -14,7 +14,14 @@ public class EventManager : MonoBehaviour
             List<System.Action> callbacks = ( (List<System.Action>) m_arglessListeners[ev] );
             foreach ( System.Action cb in callbacks )
             {
-                cb();
+                try
+                {
+                    cb();   
+                }
+                catch ( System.Exception )
+                {
+                    continue;
+                }
             }
         }
 
@@ -26,7 +33,14 @@ public class EventManager : MonoBehaviour
         List<System.Action<GameObject>> argcallbacks = ( (List<System.Action<GameObject>>) m_argListeners[ev] );
         foreach ( System.Action<GameObject> cb in argcallbacks )
         {
-            cb( obj );
+            try
+            {
+                cb( obj );   
+            }
+            catch ( System.Exception )
+            {
+                continue;
+            }
         }
     }
 


### PR DESCRIPTION
- Replaced `AssetDatabse` with `Resources` API
- Created asset paths table for easy lookup of assets without specifying exact paths
- This table is generated as a json in dev. In prod, this json is used to build the table back at boot
- AssetLoader uses this table and Resources API to supply assets
- Added try-catch in `EventManager` Fire function to make sure all callbacks are called in case one of them errors